### PR TITLE
Add edit and delete message functionality

### DIFF
--- a/backend/src/controllers/messages.controller.ts
+++ b/backend/src/controllers/messages.controller.ts
@@ -25,13 +25,24 @@ export const getMessages = async (req: Request, res: Response) => {
   const moreMessagesExist = messages.length > MESSAGES_PER_PAGE;
   const sliced = moreMessagesExist ? messages.slice(0, MESSAGES_PER_PAGE) : messages;
 
+  // Filter out deleted message content for privacy
+  const filteredMessages = sliced.map(msg => {
+    if (msg.isDeleted) {
+      return {
+        ...msg,
+        content: '', // Don't send deleted content to client
+      };
+    }
+    return msg;
+  });
+
   // Sort this specific batch in ascending order (oldest to newest) before returning
-  sliced.reverse();
+  filteredMessages.reverse();
 
   res.status(200).json({
     success: true, data: {
-      messages: sliced,
-      nextCursor: moreMessagesExist ? sliced[0]._id : null,
+      messages: filteredMessages,
+      nextCursor: moreMessagesExist ? filteredMessages[0]._id : null,
     },
   });
 };
@@ -80,13 +91,24 @@ export const getDmMessages = async (req: Request, res: Response) => {
   const moreMessagesExist = messages.length > MESSAGES_PER_PAGE;
   const sliced = moreMessagesExist ? messages.slice(0, MESSAGES_PER_PAGE) : messages;
 
+  // Filter out deleted message content for privacy
+  const filteredMessages = sliced.map(msg => {
+    if (msg.isDeleted) {
+      return {
+        ...msg,
+        content: '', // Don't send deleted content to client
+      };
+    }
+    return msg;
+  });
+
   // Sort this specific batch in ascending order (oldest to newest) before returning
-  sliced.reverse();
+  filteredMessages.reverse();
 
   res.status(200).json({
     success: true, data: {
-      messages: sliced,
-      nextCursor: moreMessagesExist ? sliced[0]._id : null,
+      messages: filteredMessages,
+      nextCursor: moreMessagesExist ? filteredMessages[0]._id : null,
     },
   });
 };

--- a/backend/src/models/message.model.ts
+++ b/backend/src/models/message.model.ts
@@ -7,6 +7,8 @@ const messageSchema = new mongoose.Schema<IMessage>({
   room: { type: mongoose.Schema.Types.ObjectId, ref: 'Room', required: true },
   isEdited: { type: Boolean, default: false },
   editedAt: { type: Date, default: null },
+  isDeleted: { type: Boolean, default: false },
+  deletedAt: { type: Date, default: null },
 }, { timestamps: true });
 
 export const Message = mongoose.model<IMessage>('Message', messageSchema);

--- a/backend/src/models/message.model.ts
+++ b/backend/src/models/message.model.ts
@@ -5,6 +5,9 @@ const messageSchema = new mongoose.Schema<IMessage>({
   content: { type: String, required: true },
   sender: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   room: { type: mongoose.Schema.Types.ObjectId, ref: 'Room', required: true },
+  isEdited: { type: Boolean, default: false },
+  editedAt: { type: Date, default: null },
+  isDeleted: { type: Boolean, default: false },
 }, { timestamps: true });
 
 export const Message = mongoose.model<IMessage>('Message', messageSchema);

--- a/backend/src/models/message.model.ts
+++ b/backend/src/models/message.model.ts
@@ -7,7 +7,6 @@ const messageSchema = new mongoose.Schema<IMessage>({
   room: { type: mongoose.Schema.Types.ObjectId, ref: 'Room', required: true },
   isEdited: { type: Boolean, default: false },
   editedAt: { type: Date, default: null },
-  isDeleted: { type: Boolean, default: false },
 }, { timestamps: true });
 
 export const Message = mongoose.model<IMessage>('Message', messageSchema);

--- a/backend/src/sockets/handlers/message/deleteMessage.ts
+++ b/backend/src/sockets/handlers/message/deleteMessage.ts
@@ -27,8 +27,10 @@ export const getDeleteMessageEventCallback = (io: TalketeerSocketServer, socket:
         throw new Error('You can only delete your own messages or messages in rooms you own');
       }
 
-      // Hard delete - permanently remove from database
-      await Message.findByIdAndDelete(messageId);
+      // Soft delete - mark as deleted (will be hard deleted after retention period)
+      message.isDeleted = true;
+      message.deletedAt = new Date();
+      await message.save();
 
       logger.info(`${socket.data.user.id} deleted message ${messageId} in room ${roomId}`, {
         userId: socket.data.user.id,

--- a/backend/src/sockets/handlers/message/deleteMessage.ts
+++ b/backend/src/sockets/handlers/message/deleteMessage.ts
@@ -1,0 +1,59 @@
+import { Message, Room } from '@src/models';
+import { ClientToServerEvents, TalketeerSocket, TalketeerSocketServer } from '@src/types';
+import logger from '@src/utils/logger.utils';
+
+export const getDeleteMessageEventCallback = (io: TalketeerSocketServer, socket: TalketeerSocket): ClientToServerEvents['deleteMessage'] => {
+  return async (roomId, messageId, ack) => {
+    if (!socket.data?.user) {
+      logger.warn('Unauthenticated user attempted to delete message');
+      return;
+    }
+
+    try {
+      const message = await Message.findById(messageId);
+
+      if (!message) {
+        throw new Error('Message not found');
+      }
+
+      const isSender = message.sender.toString() === socket.data.user.id;
+
+      // Check if user is room admin (owner)
+      const room = await Room.findById(roomId);
+      const isRoomOwner = room?.owner?.toString() === socket.data.user.id;
+
+      // Only the sender or room owner can delete the message
+      if (!isSender && !isRoomOwner) {
+        throw new Error('You can only delete your own messages or messages in rooms you own');
+      }
+
+      // Soft delete - mark as deleted instead of removing
+      message.isDeleted = true;
+      await message.save();
+
+      logger.info(`${socket.data.user.id} deleted message ${messageId} in room ${roomId}`, {
+        userId: socket.data.user.id,
+        roomId,
+        messageId,
+        deletedBy: socket.data.user.id,
+      });
+
+      // Broadcast to everyone in the room
+      io.to(roomId).emit('messageDeleted', roomId, message.sender.toString(), socket.data.user.id, messageId);
+
+      ack({ success: true });
+    } catch (err) {
+      logger.error('Error deleting message', {
+        userId: socket.data.user.id,
+        roomId,
+        messageId,
+        error: err instanceof Error ? err.message : 'Unknown error',
+        stack: err instanceof Error ? err.stack : undefined,
+      });
+      ack({
+        success: false,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    }
+  };
+};

--- a/backend/src/sockets/handlers/message/deleteMessage.ts
+++ b/backend/src/sockets/handlers/message/deleteMessage.ts
@@ -27,9 +27,8 @@ export const getDeleteMessageEventCallback = (io: TalketeerSocketServer, socket:
         throw new Error('You can only delete your own messages or messages in rooms you own');
       }
 
-      // Soft delete - mark as deleted instead of removing
-      message.isDeleted = true;
-      await message.save();
+      // Hard delete - permanently remove from database
+      await Message.findByIdAndDelete(messageId);
 
       logger.info(`${socket.data.user.id} deleted message ${messageId} in room ${roomId}`, {
         userId: socket.data.user.id,

--- a/backend/src/sockets/handlers/message/editMessage.ts
+++ b/backend/src/sockets/handlers/message/editMessage.ts
@@ -21,11 +21,6 @@ export const getEditMessageEventCallback = (io: TalketeerSocketServer, socket: T
         throw new Error('You can only edit your own messages');
       }
 
-      // Check if message is deleted
-      if (message.isDeleted) {
-        throw new Error('Cannot edit a deleted message');
-      }
-
       const oldContent = message.content;
 
       // Update the message

--- a/backend/src/sockets/handlers/message/editMessage.ts
+++ b/backend/src/sockets/handlers/message/editMessage.ts
@@ -1,0 +1,61 @@
+import { Message } from '@src/models';
+import { ClientToServerEvents, TalketeerSocket, TalketeerSocketServer } from '@src/types';
+import logger from '@src/utils/logger.utils';
+
+export const getEditMessageEventCallback = (io: TalketeerSocketServer, socket: TalketeerSocket): ClientToServerEvents['editMessage'] => {
+  return async (roomId, messageId, newContent, ack) => {
+    if (!socket.data?.user) {
+      logger.warn('Unauthenticated user attempted to edit message');
+      return;
+    }
+
+    try {
+      const message = await Message.findById(messageId);
+
+      if (!message) {
+        throw new Error('Message not found');
+      }
+
+      // Only the sender can edit their own message
+      if (message.sender.toString() !== socket.data.user.id) {
+        throw new Error('You can only edit your own messages');
+      }
+
+      // Check if message is deleted
+      if (message.isDeleted) {
+        throw new Error('Cannot edit a deleted message');
+      }
+
+      const oldContent = message.content;
+
+      // Update the message
+      message.content = newContent;
+      message.isEdited = true;
+      message.editedAt = new Date();
+      await message.save();
+
+      logger.info(`${socket.data.user.id} edited message ${messageId} in room ${roomId}`, {
+        userId: socket.data.user.id,
+        roomId,
+        messageId,
+      });
+
+      // Broadcast to everyone in the room
+      io.to(roomId).emit('messageEdited', roomId, socket.data.user.id, oldContent, newContent);
+
+      ack({ success: true });
+    } catch (err) {
+      logger.error('Error editing message', {
+        userId: socket.data.user.id,
+        roomId,
+        messageId,
+        error: err instanceof Error ? err.message : 'Unknown error',
+        stack: err instanceof Error ? err.stack : undefined,
+      });
+      ack({
+        success: false,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    }
+  };
+};

--- a/backend/src/sockets/handlers/message/index.ts
+++ b/backend/src/sockets/handlers/message/index.ts
@@ -1,6 +1,10 @@
 import { getSendMessageEventCallback } from './sendMessage';
+import { getEditMessageEventCallback } from './editMessage';
+import { getDeleteMessageEventCallback } from './deleteMessage';
 import { TalketeerSocket, TalketeerSocketServer } from '@src/types';
 
 export function registerMessageHandlers(io: TalketeerSocketServer, socket: TalketeerSocket) {
   socket.on('sendMessage', getSendMessageEventCallback(io, socket));
+  socket.on('editMessage', getEditMessageEventCallback(io, socket));
+  socket.on('deleteMessage', getDeleteMessageEventCallback(io, socket));
 }

--- a/backend/src/types/message.types.ts
+++ b/backend/src/types/message.types.ts
@@ -18,9 +18,6 @@ export interface IMessage {
     /** When the message was last edited */
     editedAt: Date | null;
 
-    /** Whether the message has been deleted (soft delete) */
-    isDeleted: boolean;
-
     updatedAt: number;
     createdAt: number;
 }

--- a/backend/src/types/message.types.ts
+++ b/backend/src/types/message.types.ts
@@ -18,6 +18,12 @@ export interface IMessage {
     /** When the message was last edited */
     editedAt: Date | null;
 
+    /** Whether the message has been soft-deleted */
+    isDeleted: boolean;
+
+    /** When the message was soft-deleted (for cleanup job) */
+    deletedAt: Date | null;
+
     updatedAt: number;
     createdAt: number;
 }

--- a/backend/src/types/message.types.ts
+++ b/backend/src/types/message.types.ts
@@ -12,6 +12,15 @@ export interface IMessage {
     /** The room the message was sent in */
     room: mongoose.Types.ObjectId;
 
+    /** Whether the message has been edited */
+    isEdited: boolean;
+
+    /** When the message was last edited */
+    editedAt: Date | null;
+
+    /** Whether the message has been deleted (soft delete) */
+    isDeleted: boolean;
+
     updatedAt: number;
     createdAt: number;
 }

--- a/backend/src/utils/cleanup.utils.ts
+++ b/backend/src/utils/cleanup.utils.ts
@@ -1,0 +1,33 @@
+import { Message } from '@src/models';
+import logger from './logger.utils';
+
+/**
+ * Hard delete messages that have been soft-deleted for more than the retention period
+ * Default retention: 30 days
+ */
+export async function cleanupDeletedMessages(retentionDays = 30): Promise<number> {
+  try {
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
+
+    const result = await Message.deleteMany({
+      isDeleted: true,
+      deletedAt: { $lte: cutoffDate },
+    });
+
+    logger.info(`Cleaned up ${result.deletedCount} soft-deleted messages older than ${retentionDays} days`, {
+      service: 'cleanup-job',
+      deletedCount: result.deletedCount,
+      retentionDays,
+    });
+
+    return result.deletedCount;
+  } catch (err) {
+    logger.error('Error cleaning up deleted messages', {
+      service: 'cleanup-job',
+      error: err instanceof Error ? err.message : 'Unknown error',
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+    throw err;
+  }
+}

--- a/backend/src/utils/db.utils.ts
+++ b/backend/src/utils/db.utils.ts
@@ -3,6 +3,7 @@ import { Room } from '@src/models/room.model';
 import { User } from '@src/models/user.model';
 import mongoose from 'mongoose';
 import logger from '@src/utils/logger.utils';
+import { cleanupDeletedMessages } from './cleanup.utils';
 
 async function clearStaleData() {
   try {
@@ -13,6 +14,9 @@ async function clearStaleData() {
 
     // Clear users' room references
     await User.updateMany({}, { $unset: { room: '' } });
+
+    // Clean up old soft-deleted messages
+    await cleanupDeletedMessages();
 
     logger.info('Cleared stale data from the database.');
   } catch (e) {

--- a/backend/src/utils/index.ts
+++ b/backend/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './api.utils';
+export * from './cleanup.utils';
 export * from './db.utils';
 export * from './jwt.utils';
 export * from './logger.utils';

--- a/frontend/src/components/chat/messages/MessageBlock.tsx
+++ b/frontend/src/components/chat/messages/MessageBlock.tsx
@@ -84,6 +84,15 @@ export const MessageBlock: FC<MessageBlockProps> = memo(({ messages, senderId })
     };
 
     const renderMessage = (message: IMessage) => {
+        // Show placeholder for deleted messages
+        if (message.isDeleted) {
+            return (
+                <div key={message._id} className="text-muted-foreground italic text-sm py-1">
+                    This message has been deleted
+                </div>
+            );
+        }
+
         if (editingMessageId === message._id) {
             return (
                 <div key={message._id} className="flex flex-col gap-2">
@@ -119,12 +128,18 @@ export const MessageBlock: FC<MessageBlockProps> = memo(({ messages, senderId })
                 </div>
                 {(canEdit || canDelete) && (
                     <DropdownMenu>
-                        <DropdownMenuTrigger className="opacity-0 group-hover:opacity-100 md:group-hover:opacity-100 transition-opacity cursor-pointer" asChild>
-                            <button className="p-1 hover:bg-accent rounded" aria-label="Message options">
+                        <DropdownMenuTrigger 
+                            className="opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity cursor-pointer" 
+                            asChild
+                        >
+                            <button 
+                                className="p-1 hover:bg-accent rounded" 
+                                aria-label="Message options"
+                            >
                                 <MoreVertical className="h-4 w-4 text-muted-foreground" />
                             </button>
                         </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="min-w-30">
+                        <DropdownMenuContent align="end">
                             {canEdit && (
                                 <DropdownMenuItem onClick={() => handleEdit(message)} className="cursor-pointer">
                                     <Pencil className="h-4 w-4 mr-2" />

--- a/frontend/src/components/chat/messages/MessageBlock.tsx
+++ b/frontend/src/components/chat/messages/MessageBlock.tsx
@@ -84,14 +84,6 @@ export const MessageBlock: FC<MessageBlockProps> = memo(({ messages, senderId })
     };
 
     const renderMessage = (message: IMessage) => {
-        if (message.isDeleted) {
-            return (
-                <div key={message._id} className="text-muted-foreground italic text-sm">
-                    This message has been deleted
-                </div>
-            );
-        }
-
         if (editingMessageId === message._id) {
             return (
                 <div key={message._id} className="flex flex-col gap-2">
@@ -127,18 +119,20 @@ export const MessageBlock: FC<MessageBlockProps> = memo(({ messages, senderId })
                 </div>
                 {(canEdit || canDelete) && (
                     <DropdownMenu>
-                        <DropdownMenuTrigger className="opacity-0 group-hover:opacity-100 transition-opacity">
-                            <MoreVertical className="h-4 w-4 text-muted-foreground" />
+                        <DropdownMenuTrigger className="opacity-0 group-hover:opacity-100 md:group-hover:opacity-100 transition-opacity cursor-pointer" asChild>
+                            <button className="p-1 hover:bg-accent rounded" aria-label="Message options">
+                                <MoreVertical className="h-4 w-4 text-muted-foreground" />
+                            </button>
                         </DropdownMenuTrigger>
-                        <DropdownMenuContent>
+                        <DropdownMenuContent align="end" className="min-w-30">
                             {canEdit && (
-                                <DropdownMenuItem onClick={() => handleEdit(message)}>
+                                <DropdownMenuItem onClick={() => handleEdit(message)} className="cursor-pointer">
                                     <Pencil className="h-4 w-4 mr-2" />
                                     Edit
                                 </DropdownMenuItem>
                             )}
                             {canDelete && (
-                                <DropdownMenuItem onClick={() => handleDelete(message._id)} className="text-destructive">
+                                <DropdownMenuItem onClick={() => handleDelete(message._id)} className="text-destructive cursor-pointer">
                                     <Trash2 className="h-4 w-4 mr-2" />
                                     Delete
                                 </DropdownMenuItem>

--- a/frontend/src/socket.ts
+++ b/frontend/src/socket.ts
@@ -2,8 +2,10 @@ import { io } from 'socket.io-client';
 import { SERVER_URL } from './config/api.config';
 import type { TalketeerSocket } from './types/socket.types';
 
+const isProduction = import.meta.env.PROD;
+
 export const socket: TalketeerSocket = io(SERVER_URL, {
     withCredentials: true,
     autoConnect: false,
-    path: '/talketeer/socket.io/'
+    path: isProduction ? '/talketeer/socket.io/' : '/socket.io/'
 }) as TalketeerSocket;

--- a/frontend/src/sockets/message.sockets.ts
+++ b/frontend/src/sockets/message.sockets.ts
@@ -20,13 +20,19 @@ export function startListeningMessageEvents(socket: TalketeerSocket, queryClient
 
     socket.on('messageEdited', (roomId, userId, oldMessage, newMessage) => {
         console.log(`${userId} edited their message in room ${roomId} from '${oldMessage}' to '${newMessage}'`);
+
+        // Invalidate the messages query to refetch updated data
+        queryClient?.invalidateQueries({ queryKey: ['messages', roomId] });
     });
 
-    socket.on('messageDeleted', (roomId, userId, deletedBy, message) => {
+    socket.on('messageDeleted', (roomId, userId, deletedBy, messageId) => {
         if (userId === deletedBy)
-            return console.log(`${deletedBy} has deleted their message from room ${roomId}: ${message}`)
+            console.log(`${deletedBy} has deleted their message from room ${roomId}: ${messageId}`)
+        else
+            console.log(`${deletedBy} has deleted ${userId}'s message: ${messageId}`);
 
-        console.log(`${deletedBy} has deleted ${userId}'s message: ${message}`);
+        // Invalidate the messages query to refetch updated data
+        queryClient?.invalidateQueries({ queryKey: ['messages', roomId] });
     });
 }
 

--- a/frontend/src/types/message.types.ts
+++ b/frontend/src/types/message.types.ts
@@ -16,9 +16,6 @@ export interface IMessage {
     /** When the message was last edited */
     editedAt?: string | null;
 
-    /** Whether the message has been deleted (soft delete) */
-    isDeleted?: boolean;
-
     createdAt: string;
     updatedAt: string;
 }

--- a/frontend/src/types/message.types.ts
+++ b/frontend/src/types/message.types.ts
@@ -10,6 +10,15 @@ export interface IMessage {
     /** The room the message was sent in */
     room: string;
 
+    /** Whether the message has been edited */
+    isEdited?: boolean;
+
+    /** When the message was last edited */
+    editedAt?: string | null;
+
+    /** Whether the message has been deleted (soft delete) */
+    isDeleted?: boolean;
+
     createdAt: string;
     updatedAt: string;
 }

--- a/frontend/src/types/message.types.ts
+++ b/frontend/src/types/message.types.ts
@@ -16,6 +16,12 @@ export interface IMessage {
     /** When the message was last edited */
     editedAt?: string | null;
 
+    /** Whether the message has been soft-deleted (not sent from backend) */
+    isDeleted?: boolean;
+
+    /** When the message was soft-deleted (not sent from backend) */
+    deletedAt?: string | null;
+
     createdAt: string;
     updatedAt: string;
 }


### PR DESCRIPTION
## Description
Implements edit and delete message functionality as requested in issue #16 

## Changes
- **Backend**: Added message edit/delete socket handlers with proper permissions (users can edit their own messages, users/room owners can delete)
- **Frontend**: Added UI with dropdown menu for edit/delete actions on hover
- **Database**: Extended message model with `isEdited`, `editedAt`, and `isDeleted` fields
- **Bug fix**: Fixed socket.io path configuration for development/production environments

## Testing
- ✅ Users can edit their own messages
- ✅ Edited messages show "(edited)" tag
- ✅ Users can delete their own messages
- ✅ Room owners can delete any message in their rooms
- ✅ Deleted messages show "This message has been deleted"
- ✅ Real-time updates work for all users in the room

## Screenshots

### Message Options Menu
![Message with three-dot menu](https://github.com/user-attachments/assets/5ba43f0c-4c64-4b8b-bae2-44186e53e7b7)
*Hover over your own messages to see the ⋮ menu with edit/delete options*

### Edit Message
![Editing a message](https://github.com/user-attachments/assets/e21639f2-0140-4648-8906-8e62cbdcb0bc)
*Click "Edit" to modify message content inline. Press Enter or click "Save" to confirm, or "Cancel" to discard changes*

### Delete Message
![Delete Message](https://github.com/user-attachments/assets/e589126f-f251-432e-ac9a-a3ddbfe311f9)
*Deleted messages show "This message has been deleted" instead of the original content*




Fixed issue #16  